### PR TITLE
Bq5 2

### DIFF
--- a/analytic_engine/logic/analytic_engine_logic.py
+++ b/analytic_engine/logic/analytic_engine_logic.py
@@ -114,4 +114,46 @@ def get_spotlight_artworks():
     except Exception as e:
         raise ValueError(f"Error fetching promoted artworks: {str(e)}")
 
-       
+def get_most_engaged_items(limit_techniques=3, limit_artists=3, limit_categories=2, limit_exhibitions=2):
+    """
+    Obtiene las técnicas, artistas y categorías de museos más "liked".
+    """
+    try:
+        # Obtener las obras más "liked" y sus detalles
+        liked_artworks = Artwork.objects.filter(usersLiked__isnull=False).distinct()
+
+        # Obtener técnicas con límite
+        techniques = liked_artworks.values('technique').annotate(like_count=Count('usersLiked')).order_by('-like_count')[:limit_techniques]
+
+        # Obtener artistas con límite
+        artists = liked_artworks.values('artist__name').annotate(like_count=Count('usersLiked')).order_by('-like_count')[:limit_artists]
+
+        # Obtener categorías de museos con límite
+        museum_categories = liked_artworks.values('museum__category').annotate(like_count=Count('usersLiked')).order_by('-like_count')[:limit_categories]
+
+        # Obtener una lista de obras más "liked" con límite
+        most_liked_artworks = liked_artworks.annotate(like_count=Count('usersLiked')).order_by('-like_count')[:limit_exhibitions]
+
+        # Crear una lista de características para la exposición
+        exhibition_details = []
+        for artwork in most_liked_artworks:
+            exhibition_details.append({
+                'name': artwork.name,
+                'artist': artwork.artist.name,
+                'technique': artwork.technique,
+                'museum': artwork.museum.name,
+                'category': artwork.museum.category
+            })
+
+        return {
+            'most_liked_techniques': list(techniques),  # Eliminar count
+            'most_liked_artists': list(artists),         # Eliminar count
+            'most_liked_museum_categories': list(museum_categories),  # Eliminar count
+            'exhibition_details': exhibition_details
+        }
+
+    except Exception as e:
+        raise ValueError(f"Error fetching most engaged items: {str(e)}")
+
+
+   

--- a/analytic_engine/urls.py
+++ b/analytic_engine/urls.py
@@ -6,5 +6,5 @@ urlpatterns = [
     path('nearest-museums/', views.nearest_museums_view), 
     path('mostliked/', views.most_liked_artwork_view),
     path('spotlights/', views.spotlight_artworks_view),
-    path('most-engaged-artworks/', views.most_engaged_artworks_view),
+    path('exhibition/', views.most_engaged_artworks_view),
 ]

--- a/analytic_engine/urls.py
+++ b/analytic_engine/urls.py
@@ -5,5 +5,6 @@ urlpatterns = [
     path('recommend/<int:user_id>', views.recommend_view),    
     path('nearest-museums/', views.nearest_museums_view), 
     path('mostliked/', views.most_liked_artwork_view),
-    path('spotlights/', views.spotlight_artworks_view), 
+    path('spotlights/', views.spotlight_artworks_view),
+    path('most-engaged-artworks/', views.most_engaged_artworks_view),
 ]

--- a/analytic_engine/views.py
+++ b/analytic_engine/views.py
@@ -77,3 +77,27 @@ def spotlight_artworks_view(request):
             return JsonResponse({'error': str(e)}, status=500)
 
     return JsonResponse({'error': 'Invalid request method'}, status=405)
+
+@csrf_exempt
+def most_engaged_artworks_view(request):
+    if request.method == 'GET':
+        try:
+            # Obtener parámetros de límite de la consulta
+            limit_techniques = int(request.GET.get('limit_techniques', 3))  
+            limit_artists = int(request.GET.get('limit_artists', 3))        
+            limit_categories = int(request.GET.get('limit_categories', 2))  
+            limit_exhibitions = int(request.GET.get('limit_exhibitions', 2)) 
+            
+            # Llamar a la lógica para obtener los elementos más comprometidos
+            engaged_items = ae.get_most_engaged_items(
+                limit_techniques=limit_techniques,
+                limit_artists=limit_artists,
+                limit_categories=limit_categories,
+                limit_exhibitions=limit_exhibitions
+            )
+            return JsonResponse(engaged_items, safe=False)
+
+        except Exception as e:
+            return JsonResponse({'error': str(e)}, status=500)
+
+    return JsonResponse({'error': 'Invalid request method'}, status=405)


### PR DESCRIPTION
Endpoint en analytic engine que permite revisar entre todos los likes, que tienen en comun en cuanto a categoria de museo, tecnica de la obra y el artista, para hacer un conteo de cuales son las cosas más famosas, y recomendar una exposición en base a ello.

Endpoint {localhost}/analytic_engine/exhibition/

Retorna cuales son los 3 artistas mas likeados, las 3 técnicas más gustadas, y las 3 categorías de museos que coinciden, y recomienda una exhibición con las obras que tienen esas 3 cualidades, permitiendo recomendar un análisis de que exhibiciones pueden crear usando obras especificas.

Prueba del endpoint:

![imagen](https://github.com/user-attachments/assets/b9bacab7-8fb4-48bf-9ebc-a33584823a5f)

